### PR TITLE
Explictly store transformed files as unsigned shorts to save disk space and memory

### DIFF
--- a/atoms_and_modules/minc_atoms.py
+++ b/atoms_and_modules/minc_atoms.py
@@ -609,7 +609,7 @@ class mincresample(CmdStage):
             self.cmd += ["-transformation", self.cxfm]              
     def finalizeCommand(self):
         """Add -2, clobber, input and output files """
-        self.cmd += ["-2", "-clobber", self.inFile, self.outfile]
+        self.cmd += ["-2", "-clobber", "-short", "-unsigned", self.inFile, self.outfile]
     def setName(self):
         self.name = "mincresample " 
     def setOutputFile(self, FH, defaultDir):
@@ -765,7 +765,7 @@ class mincAverage(CmdStage):
         self.sd = splitext(self.output)[0] + "-sd.mnc"  
         self.outputFiles += [self.output, self.sd]       
         self.cmd += ["mincaverage",
-                     "-clobber", "-normalize", "-sdfile", self.sd, "-max_buffer_size_in_kb", str(409620)] 
+                     "-clobber", "-normalize", "-short", "-unsigned", "-sdfile", self.sd, "-max_buffer_size_in_kb", str(409620)] 
                  
     def finalizeCommand(self):
         for i in range(len(self.filesToAvg)):


### PR DESCRIPTION
Changing the internal representation of mnc files seems to be save disk/memory, and improve computation time in some programs:
```
> mincresample -verbose -clobber -2 -short -unsigned -sinc -like /opt/quarantine/resources/mni_icbm152_nlin_sym_09c_minc2/mni_icbm152_t1_tal_nlin_sym_09c.mnc -transform OAS1_0422_MR1_mpr_n4_anon_sbj_111.n4correct.affine_register_masked_inverse.xfm OAS1_0422_MR1_mpr_n4_anon_sbj_111.n4correct.mnc a.mnc
> ls -lh a.mnc
-rw-r--r-- 1 devgab chalab 11M Feb 23 20:17 a.mnc
> mincresample -verbose -clobber -2 -signed -float -sinc -like /opt/quarantine/resources/mni_icbm152_nlin_sym_09c_minc2/mni_icbm152_t1_tal_nlin_sym_09c.mnc -transform OAS1_0422_MR1_mpr_n4_anon_sbj_111.n4correct.affine_register_masked_inverse.xfm OAS1_0422_MR1_mpr_n4_anon_sbj_111.n4correct.mnc b.mnc
> ls -lh b.mnc
-rw-r--r-- 1 devgab chalab 22M Feb 23 20:19 b.mnc
```